### PR TITLE
Add email replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,7 @@ For a more down-to-earth example, here's a configuration for the Parks and Recre
   }
 }
 ```
+
+## Other bits
+You may want to change the mbox files so that all the "to" addresses are to a person in the organization. This could probably be done as part of the python scripts, but here's an ad hoc way:
+regex search for `^To: .*?cpets.joonix.net>?` and replace with `To: <mailbox-owner>@cpets.joonix.net`

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The email generator requires the Enron email dataset.
 
 1.  **Download the Data:**
     ```bash
-    curl -L -o ~/Downloads/enron-email-dataset.zip -C - 
+    curl -L -o ~/Downloads/enron-email-dataset.zip -C - \
       https://www.kaggle.com/api/v1/datasets/download/wcukierski/enron-email-dataset
     ```
 2.  **Unzip and Place the File:**

--- a/config.example.json
+++ b/config.example.json
@@ -9,7 +9,26 @@
       "gandalf": ["Gandalf the Grey", "gandalf"],
       "frodo": ["Frodo Baggins", "frodo.baggins"],
       "samwise": ["Samwise Gamgee", "sam.gamgee"],
-      "aragorn": ["Aragorn", "aragorn"]
+      "aragorn": ["Aragorn", "aragorn"],
+      "pippin": ["Peregrin Took", "pippin.took"]
+    }
+  },
+  "contacts": {
+    "description": "Optional. A dictionary of other people who may be included on emails, calendar events, etc.",
+    "value": {
+        "Bilbo": ["Bilbo Baggins", "bilbo.baggins"],
+        "Merry": ["Meriadoc Brandybuck", "merry.brandybuck"],
+        "Gimli": ["Gimli son of Glóin", "gimli.sonofgloin"],
+        "Legolas": ["Legolas Greenleaf", "legolas.of.mirkwood"],
+        "Boromir": ["Boromir of Gondor", "boromir.whitecity"],
+        "Faramir": ["Faramir of Gondor", "faramir.captain"],
+        "Théoden": ["Théoden King of Rohan", "theoden.king"],
+        "Éowyn": ["Éowyn of Rohan", "eowyn.shieldmaiden"],
+        "Éomer": ["Éomer of Rohan", "eomer.marshal"],
+        "Galadriel": ["Galadriel of Lórien", "galadriel.ladyoflight"],
+        "Elrond": ["Elrond Half-elven", "elrond.perodhel"],
+        "Arwen": ["Arwen Undómiel", "arwen.evenstar"],
+        "Gollum": ["Sméagol", "smeagol.precious"],
     }
   },
   "gemini_api_key": {


### PR DESCRIPTION
This PR adds a feature which replaces all email addresses from the email corpus with addresses from the fake corporation (some of which are "contacts," as specified in `config.json`)